### PR TITLE
feat: add HTTPS server with TLS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.env
+.vscode
+cert.pem
+key.pem

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,5 +1,16 @@
 package main
 
+import (
+	"log"
+
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/server"
+)
+
 func main() {
 
+	srv := new(server.Server)
+	//Running an HTTP server from TLS to localhost:8080
+	if err := srv.Run("localhost", "8080"); err != nil {
+		log.Fatalf("error occurred while running http server: %s", err.Error())
+	}
 }

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Server encapsulates an HTTP server and provides methods for managing its lifecycle.
+type Server struct {
+	httpServer *http.Server
+}
+
+// Run starts an HTTPS server with the specified host and port.
+// Uses pre-configured TLS certificates (cert.pem and key.pem).
+// Returns an error in case of failure (for example, problems downloading certificates or a busy port).
+func (s *Server) Run(host, port string) error {
+	s.httpServer = &http.Server{
+		Addr:           host + ":" + port,
+		MaxHeaderBytes: 1 << 20,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+	}
+	// Launching a TLS-enabled server
+	return s.httpServer.ListenAndServeTLS("cert.pem", "key.pem")
+}
+
+// Shutdown stops the server correctly, ending all active connections.
+// Accepts a context for monitoring the execution time of the stop.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpServer.Shutdown(ctx)
+}


### PR DESCRIPTION
- Implement Server struct with Run and Shutdown methods
- Configure server timeouts and max header bytes
- Add TLS support with certificate and key files
- Include proper error handling and graceful shutdown
- Add comprehensive code comments for documentation

Server will serve on https://localhost:8080
Requires cert.pem and key.pem files in working directory