### PR TITLE
feat: implement user registration with password hashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.27.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/go-playground/validator/v10 v10.27.0 h1:w8+XrWVMhGkxOaaowyKH35gFydVHO
 github.com/go-playground/validator/v10 v10.27.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/app/handler/auth.go
+++ b/internal/app/handler/auth.go
@@ -1,6 +1,9 @@
 package handler
 
 import (
+	"net/http"
+
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/models"
 	"github.com/gin-gonic/gin"
 )
 
@@ -8,7 +11,25 @@ import (
 // Expected payload: {email, password, username}
 // Returns: HTTP status 201 on success, error response on failure
 func (h *Handler) signUp(c *gin.Context) {
+	var input models.User
 
+	// Bind JSON request body to User model
+	if err := c.BindJSON(&input); err != nil {
+		newErrorResponse(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Create user using authorization service
+	err := h.services.Authorization.CreateUser(input)
+	if err != nil {
+		newErrorResponse(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Return success response
+	c.JSON(http.StatusOK, map[string]interface{}{
+		"SignUp": "successful",
+	})
 }
 
 // signIn handles user authentication

--- a/internal/app/repository/mongodb/auth.go
+++ b/internal/app/repository/mongodb/auth.go
@@ -1,0 +1,39 @@
+package mongodb
+
+import (
+	"context"
+	"time"
+
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/models"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// AuthRepository implements MongoDB-specific authentication operations
+type AuthRepository struct {
+	mdb *mongo.Client
+}
+
+// NewAuthRepository creates a new authentication repository instance
+func NewAuthRepository(mdb *mongo.Client) *AuthRepository {
+	return &AuthRepository{mdb: mdb}
+}
+
+// CreateUser inserts a new user into the database
+// Generates unique ID and timestamps before insertion
+func (r *AuthRepository) CreateUser(user models.User) error {
+	// Generate unique ID for the user
+	user.Id = primitive.NewObjectID()
+
+	// Set creation and update timestamps
+	user.CreatedAt = time.Now()
+	user.UpdatedAt = time.Now()
+
+	// Insert user document into collection
+	_, err := userCol.InsertOne(context.Background(), &user)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/internal/app/repository/mongodb/mongodb.go
+++ b/internal/app/repository/mongodb/mongodb.go
@@ -3,8 +3,10 @@ package mongodb
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -17,6 +19,13 @@ type Config struct {
 	Port     string
 }
 
+const (
+	dbName         = "cardmasterDB" // Database name
+	userCollection = "users"        // User collection name
+)
+
+var userCol *mongo.Collection // Global user collection reference
+
 // NewMongoDB establishes connection to MongoDB database
 // Uses context with timeout for connection attempt
 // Returns MongoDB client instance or error if connection fails
@@ -25,7 +34,8 @@ func NewMongoDB(cfg Config) (*mongo.Client, error) {
 	defer cancel()
 
 	// Construct MongoDB connection URI from config parameters
-	mdb, err := mongo.Connect(ctx, options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s@%s:%s", cfg.User, cfg.Password, cfg.Host, cfg.Port)))
+	mdb, err := mongo.Connect(ctx, options.Client().ApplyURI(
+		fmt.Sprintf("mongodb://%s:%s@%s:%s", cfg.User, cfg.Password, cfg.Host, cfg.Port)))
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +46,44 @@ func NewMongoDB(cfg Config) (*mongo.Client, error) {
 		return nil, err
 	}
 
+	// Initialize collections
+	initCollections(mdb)
+
+	// Create database indexes
+	err = initIndexModels()
+	if err != nil {
+		log.Fatal("Failed to create indexes:", err)
+	}
+
 	fmt.Println("Connected to MongoDB!")
 
 	return mdb, nil
+}
+
+// initCollections initializes all database collections
+func initCollections(mdb *mongo.Client) {
+	userCol = mdb.Database(dbName).Collection(userCollection)
+}
+
+// initIndexModels creates database indexes for optimal query performance
+func initIndexModels() error {
+	// Define indexes for user collection
+	indexUserModels := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "email", Value: 1}}, // Index on email field
+			Options: options.Index().SetUnique(true),  // Ensure email uniqueness
+		},
+		{
+			Keys:    bson.D{{Key: "username", Value: 1}}, // Index on username field
+			Options: options.Index().SetUnique(true),     // Ensure username uniqueness
+		},
+	}
+
+	// Create indexes in database
+	_, err := userCol.Indexes().CreateMany(context.Background(), indexUserModels)
+	if err != nil {
+		return err
+	}
+
+	return err
 }

--- a/internal/app/repository/mongodb/repository.go
+++ b/internal/app/repository/mongodb/repository.go
@@ -1,25 +1,25 @@
 package mongodb
 
 import (
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/models"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+// Authorization interface defines user authentication methods
+type Authorization interface {
+	CreateUser(user models.User) error
+}
+
 // Repository provides data access methods for MongoDB
-// Will contain collection-specific methods for CRUD operations
+// Implements the Authorization interface
 type Repository struct {
-	// TODO: Add MongoDB collections as fields
-	// usersCollection *mongo.Collection
-	// postsCollection *mongo.Collection
+	Authorization
 }
 
 // NewRepository creates a new MongoDB repository instance
-// Accepts MongoDB client but doesn't initialize collections yet
+// Initializes the Authorization interface implementation
 func NewRepository(mdb *mongo.Client) *Repository {
-	return &Repository{}
-	// TODO: Initialize collections from the database
-	// db := mdb.Database("your_database_name")
-	// return &Repository{
-	//     usersCollection: db.Collection("users"),
-	//     postsCollection: db.Collection("posts"),
-	// }
+	return &Repository{
+		Authorization: NewAuthRepository(mdb),
+	}
 }

--- a/internal/app/repository/redis/auth.go
+++ b/internal/app/repository/redis/auth.go
@@ -1,0 +1,60 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisRepository implements Redis-specific cache operations
+type RedisRepository struct {
+	client *redis.Client
+}
+
+// NewRedisRepository creates a new Redis repository instance
+func NewRedisRepository(client *redis.Client) *RedisRepository {
+	return &RedisRepository{client: client}
+}
+
+// Get retrieves a value from Redis cache and unmarshals it into the destination
+func (r *RedisRepository) Get(ctx context.Context, key string, dest interface{}) error {
+	data, err := r.client.Get(ctx, key).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return fmt.Errorf("key %s: %w", key, errors.New("not found"))
+		}
+		return err
+	}
+
+	// Unmarshal JSON data into destination object
+	if err := json.Unmarshal(data, dest); err != nil {
+		return fmt.Errorf("json unmarshal error: %w", err)
+	}
+	return nil
+}
+
+// Set marshals a value to JSON and stores it in Redis cache with expiration
+func (r *RedisRepository) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("json marshal error: %w", err)
+	}
+
+	// Store value in Redis with TTL
+	if err := r.client.Set(ctx, key, data, expiration).Err(); err != nil {
+		return fmt.Errorf("redis set error: %w", err)
+	}
+	return nil
+}
+
+// Delete removes one or more keys from Redis cache
+func (r *RedisRepository) Delete(ctx context.Context, keys ...string) error {
+	if err := r.client.Del(ctx, keys...).Err(); err != nil {
+		return fmt.Errorf("redis delete error: %w", err)
+	}
+	return nil
+}

--- a/internal/app/repository/redis/cache_repository.go
+++ b/internal/app/repository/redis/cache_repository.go
@@ -1,22 +1,29 @@
 package redis
 
 import (
+	"context"
+	"time"
+
 	"github.com/redis/go-redis/v9"
 )
 
+// Authorization interface defines cache operations for authentication
+type Authorization interface {
+	Get(ctx context.Context, key string, dest interface{}) error
+	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error
+	Delete(ctx context.Context, keys ...string) error
+}
+
 // CacheRepository provides caching operations using Redis
-// Will contain methods for getting/setting cached data
+// Implements the Authorization interface
 type CacheRepository struct {
-	// TODO: Add Redis client as a field
-	// client *redis.Client
+	Authorization
 }
 
 // NewCacheRepository creates a new Redis cache repository instance
-// Accepts Redis client but doesn't store it yet
+// Initializes the Authorization interface implementation
 func NewCacheRepository(client *redis.Client) *CacheRepository {
-	return &CacheRepository{}
-	// TODO: Store Redis client for future use
-	// return &CacheRepository{
-	//     client: client,
-	// }
+	return &CacheRepository{
+		Authorization: NewRedisRepository(client),
+	}
 }

--- a/internal/app/service/auth_service.go
+++ b/internal/app/service/auth_service.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"crypto/sha1"
+	"fmt"
+
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/models"
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/repository/mongodb"
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/repository/redis"
+)
+
+const (
+	// Salt for password hashing to prevent rainbow table attacks
+	salt = "ljknsdfkgiovmsdlk&984kjsdlfj"
+)
+
+// AuthService implements business logic for authentication
+type AuthService struct {
+	repos     mongodb.Authorization
+	cacheRepo redis.Authorization
+}
+
+// NewAuthService creates a new authentication service instance
+func NewAuthService(repos mongodb.Authorization, cacheRepo redis.Authorization) *AuthService {
+	return &AuthService{
+		repos:     repos,
+		cacheRepo: cacheRepo,
+	}
+}
+
+// CreateUser creates a new user with hashed password
+func (s *AuthService) CreateUser(user models.User) error {
+	// Hash password before storing
+	user.PasswordHash = generatePasswordHash(user.PasswordHash)
+
+	// Delegate to repository for database operation
+	return s.repos.CreateUser(user)
+}
+
+// generatePasswordHash creates a SHA1 hash of the password with salt
+func generatePasswordHash(password string) string {
+	hash := sha1.New()
+	hash.Write([]byte(password))
+
+	// Return hexadecimal representation of the hash
+	return fmt.Sprintf("%x", hash.Sum([]byte(salt)))
+}

--- a/internal/app/service/service.go
+++ b/internal/app/service/service.go
@@ -1,25 +1,26 @@
 package service
 
 import (
+	"github.com/evgeney-fullstack/cardmaster-app/internal/app/models"
 	"github.com/evgeney-fullstack/cardmaster-app/internal/app/repository/mongodb"
 	"github.com/evgeney-fullstack/cardmaster-app/internal/app/repository/redis"
 )
 
+// Authorization interface defines authentication service methods
+type Authorization interface {
+	CreateUser(user models.User) error
+}
+
 // Service represents the business logic layer of the application
 // It orchestrates data flow between repositories and handlers
 type Service struct {
-	// TODO: Add fields for repositories when implemented
-	// repos *mongodb.Repository
-	// cache *redis.CacheRepository
+	Authorization
 }
 
 // NewService creates a new Service instance with dependencies injection
-// Currently accepts repositories but doesn't utilize them (to be implemented)
+// Initializes the Authorization service with MongoDB and Redis repositories
 func NewService(repos *mongodb.Repository, cacheRepo *redis.CacheRepository) *Service {
-	return &Service{}
-	// TODO: Store dependencies in Service struct for future use
-	// return &Service{
-	//     repos: repos,
-	//     cache: cacheRepo,
-	// }
+	return &Service{
+		Authorization: NewAuthService(repos.Authorization, cacheRepo.Authorization),
+	}
 }


### PR DESCRIPTION
- Add user registration endpoint with request validation
- Implement password hashing with SHA1 and salt
- Create MongoDB repository for user operations
- Add Redis cache repository for future use
- Set up database indexes for optimal performance
- Implement service layer for authentication business logic

This commit completes the user registration flow from API endpoint to database storage. Passwords are hashed with SHA1 and a salt before storage for security.